### PR TITLE
don't append sys.path

### DIFF
--- a/scripts/ImageManager.py
+++ b/scripts/ImageManager.py
@@ -1,7 +1,4 @@
-import sys
-import os
 from pathlib import Path
-sys.path.append(os.path.dirname(__file__))
 from PIL import Image, ImageFilter, ImageDraw
 import numpy as np
 from modules import scripts, shared
@@ -9,7 +6,7 @@ import random
 import os
 import cv2
 import gradio as gr
-import ImageProcessing
+from scripts import ImageProcessing  # noqa
 from datetime import datetime
 
 base_dir = Path(scripts.basedir())

--- a/scripts/ImageProcessing.py
+++ b/scripts/ImageProcessing.py
@@ -1,8 +1,6 @@
-import sys
 import os
-sys.path.append(os.path.dirname(__file__))
 
-import ImageManager
+from scripts import ImageManager  # noqa
 import cv2
 import numpy as np
 import json

--- a/scripts/MangaMakerUI.py
+++ b/scripts/MangaMakerUI.py
@@ -1,10 +1,9 @@
 import sys
 import os
-sys.path.append(os.path.dirname(__file__))
 
 from modules import scripts, shared
 import gradio as gr
-import ImageManager
+from scripts import ImageManager  # noqa
 import platform
 import subprocess as sp
 


### PR DESCRIPTION
you don't need to append sys.path
the scripts dir is a shared name sapce for all extentions

tip: if you are using an IDE you can set you extention dir as sorce root so the IDE knows what is what