### PR TITLE
'Generate all pages' synchronously on a page-by-page basis (comfyui)

### DIFF
--- a/SP-MangaEditer/js/ai/AIManagement.js
+++ b/SP-MangaEditer/js/ai/AIManagement.js
@@ -32,11 +32,11 @@ function existsWaitQueue() {
 }
 
 
-function T2I( layer, spinner ){
+async function T2I( layer, spinner ){
   if (API_mode == apis.A1111) {
     sdwebui_T2IProcessQueue(layer, spinner.id);
   }else if (API_mode == apis.COMFYUI){
-    Comfyui_handle_process_queue(layer, spinner.id);
+    return Comfyui_handle_process_queue(layer, spinner.id);
   }
 }
 function I2I( layer, spinner ){

--- a/SP-MangaEditer/js/ai/ComfyUI/ComfyuiManagement.js
+++ b/SP-MangaEditer/js/ai/ComfyUI/ComfyuiManagement.js
@@ -262,7 +262,7 @@ async function Comfyui_handle_process_queue(layer, spinnerId, isT2I = true) {
 
   console.log("comfyuiQueue Workflow", JSON.stringify(workflow));
 
-  comfyuiQueue.add(async () => Comfyui_put_queue(workflow))
+  return comfyuiQueue.add(async () => Comfyui_put_queue(workflow))
     .then(async (result) => {
       if (result && result.error) {
         createToastError("Generation Error", result.message);

--- a/SP-MangaEditer/js/ai/prompt/auto/AutoGeneration.js
+++ b/SP-MangaEditer/js/ai/prompt/auto/AutoGeneration.js
@@ -2,11 +2,15 @@ async function autoMultiGenerate(){
   let guidList = btmGetGuids();
   for (const [index, guid] of guidList.entries()) {
     await chengeCanvasByGuid(guid);
+
+    const promises = [];
     let panelList = getPanelObjectList();
     panelList.forEach((panel, panelIndex) =>{
       var spinner = createSpinner(canvasMenuIndex);
-      T2I( panel, spinner );
+      promises.push(T2I( panel, spinner ));
     });
+    await Promise.all(promises);
+
     while(true){
       if( existsWaitQueue() ){
         await new Promise(r => setTimeout(r, 2000));


### PR DESCRIPTION
### Issue
When using comfyui, “Generate All Pages” generates all images on the last page.

### Cause
It seems that the asynchronous execution of comfyui is not tied to the page information.
(Probably it draws on the currently active page).
Therefore, the comfyui execution is completed after the page switching is completed first, and all images are drawn on the last page.

### Changes
I have made comfyui execution synchronous on a page-by-page basis.

### Other
This method has a performance penalty because it has to wait for generation on a page-by-page basis.
Ideally, the page id should be passed to the comfyui execution so that inactive pages are also rendered, but I have not been able to investigate how to achieve this.
If you have a way to do this, please drop this change.
The same problem may also occur with webui, but I have not included it in this change because I have not confirmed that it works.

Thank you for your excellent service.

---

### 問題
comfyui 利用時に「全ページ生成」を実行すると、最後のページに全画像が生成されます。

### 原因
非同期に行われる comfyui の実行にページ情報が紐づいていないようです。
（おそらく現在アクティブなページに描画される）
そのためページの切り替えが先に完了した後に comfyui の実行が完了し、最後のページに全ての画像が描画されています。

### 対応
ページ単位で comfyui の実行を同期的に行うようにしました。

### その他
この方法はページ単位で生成を待つ必要があるため、パフォーマンスが低下します。
理想は comfyui の実行にページid を渡してアクティブでないページにも描画を行うことですが、実現方法を調査しきれず実施できていません。
もしその方法があればこの変更は取り下げてください。
また、webui でも同じ問題が起こっている可能性がありますが、動作を確認していないため今回の変更には含めていません。

素晴らしいサービスをありがとうございます。
